### PR TITLE
Add repository settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,10 @@
+_extends: .github
+
+repository:
+  name: obsidian-publisher
+  description: "Publish Obsidian notes to GitHub for Hugo processing. This plugin converts Obsidian syntax (wikilinks, image references) to Hugo markdown and uploads files via the GitHub API."
+  homepage: https://philoserf.github.io/obsidian-publisher/
+  topics:
+    - github-pages
+    - hugo
+    - obsidian-plugin


### PR DESCRIPTION
Add `.github/settings.yml` for declarative repo settings via [probot/settings](https://github.com/repository-settings/app).

This config extends the base settings from `philoserf/.github` and includes repo-specific metadata and overrides.

Settings are applied automatically when the Settings app is installed and this PR is merged.