### PR TITLE
chore: pin dependency versions and use latest biome schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "obsidian-publisher",
       "dependencies": {
-        "@octokit/rest": "latest",
+        "@octokit/rest": "^22.0.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "latest",
-        "@types/bun": "latest",
-        "@types/node": "latest",
-        "obsidian": "latest",
-        "typescript": "latest",
+        "@biomejs/biome": "^2.4.3",
+        "@types/bun": "^1.3.9",
+        "@types/node": "^25.3.0",
+        "obsidian": "^1.12.2",
+        "typescript": "^5.9.3",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Pin dependency versions in `bun.lock` from `latest` to specific semver ranges
- Update `biome.json` schema URL from `2.4.3` to `latest`

## Test plan

- [x] `bun run validate` passes (types, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)