### PR TITLE
chore: add deploy script for local plugin testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format:check": "biome format .",
     "validate": "bun run scripts/validate-plugin.ts",
     "version": "bun run version-bump.ts",
+    "deploy": "cp main.js manifest.json ~/source/mine/notes/.obsidian/plugins/publisher/",
     "test": "bun test",
     "test:watch": "bun test --watch"
   },


### PR DESCRIPTION
## Summary

- Adds a `deploy` script to `package.json` that copies `main.js` and `manifest.json` to the local Obsidian vault plugins directory for quick iteration during development

## Test plan

- [x] `bun test` passes (10/10)
- [ ] Run `bun run deploy` after `bun run build` and verify files appear in the plugins directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)