### PR TITLE
fix: normalize directory paths to prevent double-slash in API calls

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,7 +70,9 @@ export class PublisherSettingTab extends PluginSettingTab {
           .setPlaceholder("content/posts")
           .setValue(this.plugin.settings.contentDir)
           .onChange(async (value) => {
-            this.plugin.settings.contentDir = value.trim();
+            this.plugin.settings.contentDir = value
+              .trim()
+              .replace(/^\/+|\/+$/g, "");
             await this.plugin.saveSettings();
           }),
       );
@@ -84,7 +86,9 @@ export class PublisherSettingTab extends PluginSettingTab {
           .setPlaceholder("static/images")
           .setValue(this.plugin.settings.imageDir)
           .onChange(async (value) => {
-            this.plugin.settings.imageDir = value.trim();
+            this.plugin.settings.imageDir = value
+              .trim()
+              .replace(/^\/+|\/+$/g, "");
             await this.plugin.saveSettings();
           }),
       );


### PR DESCRIPTION
## Summary
- Strips leading/trailing slashes from `contentDir` and `imageDir` when saving settings
- Prevents double-slash or absolute-path issues in GitHub API paths

Fixes #27

## Test plan
- [ ] Enter `content/posts/` (trailing slash) in Content Directory — verify slash is stripped on save
- [ ] Enter `/static/images` (leading slash) in Image Directory — verify slash is stripped on save
- [ ] Publish a note and confirm API paths are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)