### PR TITLE
fix: preserve YAML structure in frontmatter template

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,11 @@
-import { type App, Notice, PluginSettingTab, Setting } from "obsidian";
+import {
+  type App,
+  Notice,
+  PluginSettingTab,
+  parseYaml,
+  Setting,
+  stringifyYaml,
+} from "obsidian";
 import { GitHubService } from "./github-service";
 import type ObsidianPublisher from "./main";
 
@@ -185,31 +192,39 @@ export class PublisherSettingTab extends PluginSettingTab {
       );
   }
 
-  private serializeFrontmatter(template: Record<string, string>): string {
-    return Object.entries(template)
-      .map(([key, value]) => `${key}: ${value}`)
-      .join("\n");
+  private serializeFrontmatter(template: Record<string, unknown>): string {
+    if (Object.keys(template).length === 0) return "";
+    try {
+      return stringifyYaml(template).trim();
+    } catch {
+      return Object.entries(template)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join("\n");
+    }
   }
 
-  private parseFrontmatter(text: string): Record<string, string> {
-    const result: Record<string, string> = {};
-    const lines = text.split("\n");
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-
-      const colonIndex = trimmed.indexOf(":");
-      if (colonIndex === -1) continue;
-
-      const key = trimmed.slice(0, colonIndex).trim();
-      const value = trimmed.slice(colonIndex + 1).trim();
-
-      if (key && value) {
-        result[key] = value;
-      }
+  private parseFrontmatter(text: string): Record<string, unknown> {
+    const trimmed = text.trim();
+    if (!trimmed) return {};
+    try {
+      const parsed = parseYaml(trimmed);
+      return typeof parsed === "object" && parsed !== null ? parsed : {};
+    } catch {
+      return this.parseSimpleFrontmatter(trimmed);
     }
+  }
 
+  private parseSimpleFrontmatter(text: string): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const line of text.split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      const colonIndex = t.indexOf(":");
+      if (colonIndex === -1) continue;
+      const key = t.slice(0, colonIndex).trim();
+      const value = t.slice(colonIndex + 1).trim();
+      if (key && value) result[key] = value;
+    }
     return result;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface PublisherSettings {
   /** Image directory path in the Hugo repository (e.g., "static/images") */
   imageDir: string;
   /** Additional frontmatter fields to inject during publishing */
-  frontmatterTemplate: Record<string, string>;
+  frontmatterTemplate: Record<string, unknown>;
   /** Whether to remove the status: published field from frontmatter */
   removePublishFlag: boolean;
   /** Base branch to create PRs against (default: "main") */


### PR DESCRIPTION
## Summary
- Replaces hand-rolled key-value parser with Obsidian's `parseYaml()` for the frontmatter template textarea
- Updates `frontmatterTemplate` type from `Record<string, string>` to `Record<string, unknown>` to support arrays/objects
- Uses `stringifyYaml()` for serialization back to the textarea
- Falls back to simple key-value parsing if YAML parsing fails

Fixes #26

## Test plan
- [ ] Enter `tags: [obsidian, hugo]` in frontmatter template — verify it persists as an array
- [ ] Enter `categories: [blog]` — verify published frontmatter contains a YAML array, not a quoted string
- [ ] Enter invalid YAML — verify fallback to simple parsing works
- [ ] Verify existing simple `key: value` entries still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)