### PR TITLE
fix: clean up orphaned branch when PR creation fails

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -291,6 +291,17 @@ export class GitHubService {
   }
 
   /**
+   * Delete a branch from the repository
+   */
+  async deleteBranch(branchName: string): Promise<void> {
+    await this.octokit.rest.git.deleteRef({
+      owner: this.settings.repoOwner,
+      repo: this.settings.repoName,
+      ref: `heads/${branchName}`,
+    });
+  }
+
+  /**
    * Generate a unique branch name for publishing
    */
   generateBranchName(prefix = "publish"): string {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -184,6 +184,13 @@ export class Publisher {
         prUrl: pr.url,
       };
     } catch (error) {
+      if (branchName) {
+        try {
+          await this.githubService.deleteBranch(branchName);
+        } catch {
+          // Best-effort cleanup — don't mask the original error
+        }
+      }
       const message = error instanceof Error ? error.message : "Unknown error";
       return {
         filePath: file.path,
@@ -299,6 +306,13 @@ export class Publisher {
         prUrl: pr.url,
       };
     } catch (error) {
+      if (branchName) {
+        try {
+          await this.githubService.deleteBranch(branchName);
+        } catch {
+          // Best-effort cleanup — don't mask the original error
+        }
+      }
       const message = error instanceof Error ? error.message : "Unknown error";
       new Notice(`Failed to publish: ${message}`);
 


### PR DESCRIPTION
## Summary
- Adds `deleteBranch()` method to `GitHubService`
- Calls it in catch blocks of `publishNoteWithPR()` and `publishAllWithPR()` when a branch was created but PR creation failed
- Cleanup is best-effort (errors swallowed) to avoid masking the original error

Fixes #25

## Test plan
- [ ] Simulate PR creation failure (e.g., invalid base branch) — verify the feature branch is deleted
- [ ] Normal publish-with-PR workflow still works end-to-end
- [ ] Batch publish-with-PR workflow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)