### PR TITLE
perf: optimize image lookup and base64 encoding

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -170,13 +170,12 @@ export class GitHubService {
    * Convert string to base64 (cross-platform)
    */
   private stringToBase64(str: string): string {
-    const encoder = new TextEncoder();
-    const bytes = encoder.encode(str);
-    let binary = "";
-    for (const byte of bytes) {
-      binary += String.fromCharCode(byte);
+    const bytes = new TextEncoder().encode(str);
+    const chunks: string[] = [];
+    for (let i = 0; i < bytes.length; i += 8192) {
+      chunks.push(String.fromCharCode(...bytes.subarray(i, i + 8192)));
     }
-    return btoa(binary);
+    return btoa(chunks.join(""));
   }
 
   /**
@@ -184,11 +183,11 @@ export class GitHubService {
    */
   private arrayBufferToBase64(buffer: ArrayBuffer): string {
     const bytes = new Uint8Array(buffer);
-    let binary = "";
-    for (const byte of bytes) {
-      binary += String.fromCharCode(byte);
+    const chunks: string[] = [];
+    for (let i = 0; i < bytes.length; i += 8192) {
+      chunks.push(String.fromCharCode(...bytes.subarray(i, i + 8192)));
     }
-    return btoa(binary);
+    return btoa(chunks.join(""));
   }
 
   /**

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -321,12 +321,12 @@ export class Publisher {
     imageNames: string[],
     branch?: string,
   ): Promise<void> {
+    const filesByName = new Map(this.vault.getFiles().map((f) => [f.name, f]));
+
     for (const imageName of imageNames) {
       try {
         // Find the image file in the vault
-        const imageFile = this.vault
-          .getFiles()
-          .find((f) => f.name === imageName);
+        const imageFile = filesByName.get(imageName);
 
         if (!imageFile) {
           console.warn(`Image not found in vault: ${imageName}`);


### PR DESCRIPTION
## Summary
- **Image lookup (#28):** Builds a `Map<string, TFile>` from `vault.getFiles()` once before the upload loop instead of calling `getFiles().find()` per image — O(N+M) instead of O(N*M)
- **Base64 encoding (#29):** Replaces O(n²) string concatenation with chunked array + `join("")` in both `stringToBase64()` and `arrayBufferToBase64()`

Fixes #28
Fixes #29

## Test plan
- [ ] Publish a note with multiple images — verify all images upload correctly
- [ ] Publish a note with large content — verify base64 encoding works
- [ ] Verify no regressions in direct commit and PR workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)