### PR TITLE
chore: remove categories from frontmatter placeholder

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -170,9 +170,7 @@ export class PublisherSettingTab extends PluginSettingTab {
 
     new Setting(containerEl).addTextArea((text) => {
       text
-        .setPlaceholder(
-          "author: Your Name\ncategories: [blog]\ntags: [obsidian]",
-        )
+        .setPlaceholder("author: Your Name\ntags: [obsidian]")
         .setValue(
           this.serializeFrontmatter(this.plugin.settings.frontmatterTemplate),
         )


### PR DESCRIPTION
## Summary
- Removes `categories: [blog]` from the frontmatter template placeholder text in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)