### PR TITLE
fix: delete status field instead of setting to undefined

### DIFF
--- a/src/content-processor.ts
+++ b/src/content-processor.ts
@@ -79,7 +79,7 @@ export class ContentProcessor {
 
     // Remove status field if configured
     if (this.settings.removePublishFlag) {
-      processed.status = undefined;
+      delete processed.status;
     }
 
     // Add template fields


### PR DESCRIPTION
## Summary
- Changes `processed.status = undefined` to `delete processed.status` so the key is fully removed before YAML serialization
- Prevents `status: null` or `status: ~` from appearing in published frontmatter

Fixes #23

## Test plan
- [ ] Publish a note with `removePublishFlag` enabled — verify `status` field is absent from output, not null

🤖 Generated with [Claude Code](https://claude.com/claude-code)