### PR TITLE
chore: remove unused GitHubFile type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -85,15 +85,3 @@ export interface BatchPublishResult {
   /** URL to the pull request if created */
   prUrl?: string;
 }
-
-/**
- * GitHub file response
- */
-export interface GitHubFile {
-  /** File SHA for updates */
-  sha: string;
-  /** File content (base64 encoded) */
-  content: string;
-  /** Download URL */
-  download_url: string;
-}


### PR DESCRIPTION
## Summary
- Removes unused `GitHubFile` interface from `types.ts`

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)