### PR TITLE
fix: improve type safety in GitHub error handling

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -1,3 +1,4 @@
+import { RequestError } from "@octokit/request-error";
 import { Octokit } from "@octokit/rest";
 import type { PublisherSettings } from "./types";
 
@@ -62,12 +63,7 @@ export class GitHubService {
       return "sha" in response.data ? response.data.sha : null;
     } catch (error) {
       // 404 means file doesn't exist, which is fine
-      if (
-        error &&
-        typeof error === "object" &&
-        "status" in error &&
-        error.status === 404
-      ) {
+      if (error instanceof RequestError && error.status === 404) {
         return null;
       }
       throw error;
@@ -100,7 +96,7 @@ export class GitHubService {
         path,
         message,
         content: this.stringToBase64(content),
-        sha: existingSha || undefined,
+        sha: existingSha ?? undefined,
       };
 
       if (branch) {
@@ -147,7 +143,7 @@ export class GitHubService {
         path,
         message: `Upload image: ${filename}`,
         content: base64Content,
-        sha: existingSha || undefined,
+        sha: existingSha ?? undefined,
       };
 
       if (branch) {
@@ -328,12 +324,7 @@ export class GitHubService {
         return branchName;
       } catch (error) {
         // Check if error is 422 (branch already exists)
-        if (
-          error &&
-          typeof error === "object" &&
-          "status" in error &&
-          error.status === 422
-        ) {
+        if (error instanceof RequestError && error.status === 422) {
           // Branch already exists, try again with suffix
           continue;
         }


### PR DESCRIPTION
## Summary
- Import `RequestError` from `@octokit/request-error` for typed status code checks (404, 422)
- Replace `typeof error === "object" && "status" in error` pattern with `error instanceof RequestError`
- Use nullish coalescing (`??`) instead of logical OR (`||`) for SHA fallback

Fixes #8

## Test plan
- [ ] Publish to a new file (triggers 404 path in `getFileSha`) — verify it works
- [ ] Publish to an existing file (triggers SHA lookup) — verify update works
- [ ] Branch collision retry (triggers 422 path) — verify retry logic works

🤖 Generated with [Claude Code](https://claude.com/claude-code)