### PR TITLE
fix: report failed image uploads to the user

### DIFF
--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -334,7 +334,8 @@ export class Publisher {
   private async uploadImages(
     imageNames: string[],
     branch?: string,
-  ): Promise<void> {
+  ): Promise<string[]> {
+    const failedImages: string[] = [];
     const filesByName = new Map(this.vault.getFiles().map((f) => [f.name, f]));
 
     for (const imageName of imageNames) {
@@ -344,6 +345,7 @@ export class Publisher {
 
         if (!imageFile) {
           console.warn(`Image not found in vault: ${imageName}`);
+          failedImages.push(imageName);
           continue;
         }
 
@@ -362,9 +364,17 @@ export class Publisher {
         );
       } catch (error) {
         console.error(`Failed to upload image ${imageName}:`, error);
-        // Don't throw - continue with other images
+        failedImages.push(imageName);
       }
     }
+
+    if (failedImages.length > 0) {
+      new Notice(
+        `Warning: ${failedImages.length} image(s) failed to upload: ${failedImages.join(", ")}`,
+      );
+    }
+
+    return failedImages;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `uploadImages()` now returns a list of failed image names
- Shows a `Notice` warning when image uploads fail, listing which images
- Missing vault images now tracked as failures instead of silently skipped

Fixes #7

## Test plan
- [ ] Publish a note with valid images — verify no warning shown
- [ ] Publish a note referencing a non-existent image — verify warning Notice appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)