### PR TITLE
test: add ContentProcessor unit tests, fix image conversion order

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/__mocks__/preload.ts"]

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -1,0 +1,55 @@
+/**
+ * Minimal mock of Obsidian APIs for testing.
+ * parseYaml/stringifyYaml use JSON as a stand-in since we only need
+ * basic object round-tripping in tests.
+ */
+
+export function parseYaml(text: string): unknown {
+  // Simple YAML parser for test fixtures: handles key: value lines,
+  // arrays like [a, b], and quoted strings
+  const result: Record<string, unknown> = {};
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = trimmed.slice(0, colonIdx).trim();
+    let value: unknown = trimmed.slice(colonIdx + 1).trim();
+
+    // Parse arrays like [a, b]
+    if (
+      typeof value === "string" &&
+      value.startsWith("[") &&
+      value.endsWith("]")
+    ) {
+      value = value
+        .slice(1, -1)
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    }
+    // Parse booleans and numbers
+    else if (value === "true") value = true;
+    else if (value === "false") value = false;
+    else if (typeof value === "string" && /^\d+$/.test(value))
+      value = Number(value);
+
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+export function stringifyYaml(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      lines.push(`${key}: [${value.join(", ")}]`);
+    } else {
+      lines.push(`${key}: ${value}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export class Notice {}

--- a/src/__mocks__/preload.ts
+++ b/src/__mocks__/preload.ts
@@ -1,0 +1,3 @@
+import { mock } from "bun:test";
+
+mock.module("obsidian", () => require("./obsidian"));

--- a/src/content-processor.test.ts
+++ b/src/content-processor.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import { ContentProcessor } from "./content-processor";
+import type { PublisherSettings } from "./types";
+import { DEFAULT_SETTINGS } from "./types";
+
+function makeProcessor(
+  overrides: Partial<PublisherSettings> = {},
+): ContentProcessor {
+  return new ContentProcessor({ ...DEFAULT_SETTINGS, ...overrides });
+}
+
+function wrap(frontmatter: string, body: string): string {
+  return `---\n${frontmatter}\n---\n${body}`;
+}
+
+describe("Wikilink conversion", () => {
+  const cp = makeProcessor();
+
+  test("converts simple wikilink", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "See [[Page Name]] here"),
+      "test.md",
+    );
+    expect(result.content).toContain("[Page Name](page-name)");
+  });
+
+  test("converts wikilink with display text", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "See [[Page|Custom Text]] here"),
+      "test.md",
+    );
+    expect(result.content).toContain("[Custom Text](page)");
+  });
+
+  test("sanitizes wikilink target", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "[[My Cool Page]]"),
+      "test.md",
+    );
+    expect(result.content).toContain("[My Cool Page](my-cool-page)");
+  });
+
+  test("handles multiple wikilinks", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "[[One]] and [[Two]]"),
+      "test.md",
+    );
+    expect(result.content).toContain("[One](one)");
+    expect(result.content).toContain("[Two](two)");
+  });
+});
+
+describe("Image reference conversion", () => {
+  const cp = makeProcessor();
+
+  test("converts image reference", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "![[photo.png]]"),
+      "test.md",
+    );
+    expect(result.content).toContain("![photo.png](/images/photo.png)");
+  });
+
+  test("sanitizes image filename", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "![[My Photo.jpg]]"),
+      "test.md",
+    );
+    expect(result.content).toContain("![My Photo.jpg](/images/my-photo.jpg)");
+  });
+
+  test("extracts image names", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "![[a.png]] text ![[b.jpg]]"),
+      "test.md",
+    );
+    expect(result.images).toEqual(["a.png", "b.jpg"]);
+  });
+
+  test("no images returns empty array", () => {
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "no images here"),
+      "test.md",
+    );
+    expect(result.images).toEqual([]);
+  });
+});
+
+describe("Frontmatter processing", () => {
+  test("adds date when missing", () => {
+    const cp = makeProcessor();
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "body"),
+      "test.md",
+    );
+    expect(result.frontmatter.date).toBeDefined();
+  });
+
+  test("preserves existing date", () => {
+    const cp = makeProcessor();
+    const result = cp.process(
+      wrap("title: Test\ndate: 2026-01-01\nstatus: published", "body"),
+      "test.md",
+    );
+    expect(result.frontmatter.date).toBe("2026-01-01");
+  });
+
+  test("removes status field when removePublishFlag is true", () => {
+    const cp = makeProcessor({ removePublishFlag: true });
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "body"),
+      "test.md",
+    );
+    expect(result.frontmatter.status).toBeUndefined();
+    expect("status" in result.frontmatter).toBe(false);
+  });
+
+  test("keeps status field when removePublishFlag is false", () => {
+    const cp = makeProcessor({ removePublishFlag: false });
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "body"),
+      "test.md",
+    );
+    expect(result.frontmatter.status).toBe("published");
+  });
+
+  test("merges template fields without overriding existing", () => {
+    const cp = makeProcessor({
+      frontmatterTemplate: { author: "Mark", tags: ["obsidian"] },
+    });
+    const result = cp.process(
+      wrap("title: Existing\nauthor: Someone Else\nstatus: published", "body"),
+      "test.md",
+    );
+    expect(result.frontmatter.author).toBe("Someone Else");
+    expect(result.frontmatter.tags).toEqual(["obsidian"]);
+  });
+
+  test("adds template fields when not present", () => {
+    const cp = makeProcessor({
+      frontmatterTemplate: { author: "Mark" },
+    });
+    const result = cp.process(
+      wrap("title: Test\nstatus: published", "body"),
+      "test.md",
+    );
+    expect(result.frontmatter.author).toBe("Mark");
+  });
+});
+
+describe("Filename sanitization", () => {
+  const cp = makeProcessor();
+
+  test("converts to lowercase with hyphens", () => {
+    expect(cp.sanitizeFilename("My Blog Post.md")).toBe("my-blog-post.md");
+  });
+
+  test("removes special characters", () => {
+    expect(cp.sanitizeFilename("Special!@#$%Chars.md")).toBe("specialchars.md");
+  });
+
+  test("handles empty result", () => {
+    expect(cp.sanitizeFilename("@#$%.md")).toBe("untitled.md");
+  });
+});
+
+describe("Full process pipeline", () => {
+  test("transforms complete note", () => {
+    const cp = makeProcessor({ removePublishFlag: true });
+    const input = wrap(
+      "title: My Post\nstatus: published",
+      "Hello [[World]]!\n\n![[screenshot.png]]\n",
+    );
+    const result = cp.process(input, "My Post.md");
+
+    expect(result.filename).toBe("my-post.md");
+    expect(result.content).toContain("[World](world)");
+    expect(result.content).toContain(
+      "![screenshot.png](/images/screenshot.png)",
+    );
+    expect(result.images).toEqual(["screenshot.png"]);
+    expect(result.frontmatter.title).toBe("My Post");
+    expect("status" in result.frontmatter).toBe(false);
+  });
+});

--- a/src/content-processor.ts
+++ b/src/content-processor.ts
@@ -22,8 +22,8 @@ export class ContentProcessor {
 
     // Convert content
     let processedBody = body;
-    processedBody = this.convertWikilinks(processedBody);
     processedBody = this.convertImageReferences(processedBody);
+    processedBody = this.convertWikilinks(processedBody);
 
     // Reassemble content with frontmatter
     const processedContent = this.assembleFrontmatter(


### PR DESCRIPTION
## Summary
- Adds 18 unit tests for `ContentProcessor`: wikilinks, image references, frontmatter processing, filename sanitization, end-to-end pipeline
- **Bug fix:** Swapped `convertWikilinks` and `convertImageReferences` order — wikilink regex was consuming `![[image]]` patterns before the image converter could process them
- Adds Obsidian module mock and bun test preload infrastructure

Fixes #12

## Test plan
- [x] All 28 tests pass (`bun test`)
- [ ] Publish a note with images — verify `/images/` prefix now appears in converted references

🤖 Generated with [Claude Code](https://claude.com/claude-code)