### PR TITLE
chore: use standard chore label for PRs

### DIFF
--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -96,7 +96,7 @@ export class Publisher {
         this.settings.baseBranch || "main",
         prTitle,
         prBody,
-        this.settings.prLabels || ["published-from-obsidian"],
+        this.settings.prLabels || ["chore"],
       );
 
       return { ...result, prUrl: pr.url };
@@ -159,7 +159,7 @@ export class Publisher {
         this.settings.baseBranch || "main",
         prTitle,
         prBody,
-        this.settings.prLabels || ["published-from-obsidian"],
+        this.settings.prLabels || ["chore"],
       );
 
       return {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -137,7 +137,7 @@ export class PublisherSettingTab extends PluginSettingTab {
       .setDesc("Comma-separated labels to add to pull requests")
       .addText((text) =>
         text
-          .setPlaceholder("published-from-obsidian")
+          .setPlaceholder("chore")
           .setValue(this.plugin.settings.prLabels.join(", "))
           .onChange(async (value) => {
             this.plugin.settings.prLabels = value

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export const DEFAULT_SETTINGS: PublisherSettings = {
   frontmatterTemplate: {},
   removePublishFlag: false,
   baseBranch: "main",
-  prLabels: ["published-from-obsidian"],
+  prLabels: ["chore"],
   usePullRequests: true,
 };
 


### PR DESCRIPTION
## Summary

- Change default PR label from `published-from-obsidian` to `chore`
- Aligns with the standardized label superset across all philoserf repos

## Test plan

- [x] `bun run validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)