### PR TITLE
fix: declare @octokit/request-error as explicit dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "obsidian-publisher",
       "dependencies": {
+        "@octokit/request-error": "^7.1.0",
         "@octokit/rest": "^22.0.1",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "deploy": "cp main.js manifest.json ~/source/philoserf/notes/.obsidian/plugins/publisher/"
   },
   "dependencies": {
+    "@octokit/request-error": "^7.1.0",
     "@octokit/rest": "^22.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Add `@octokit/request-error` to `dependencies` in `package.json`
- Was only available as a transitive dep of `@octokit/rest`, fragile across major bumps

Closes #67

## Test plan

- [x] `bun run validate` — types, lint, build all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)