### PR TITLE
fix: restrict release workflow to semver tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Change tag filter from `*` (any tag) to `[0-9]+.[0-9]+.[0-9]+` (semver only)
- Prevents accidental releases from non-version tags

Closes #65

## Test plan

- [x] Pattern matches `1.2.3` — would trigger
- [x] Pattern rejects `test-tag`, `v1-backup` — would not trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)