### PR TITLE
fix: include test files in type checking and add tests to validate

### DIFF
--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -42,6 +42,16 @@ if (checkResult.exitCode === 0) {
   errors++;
 }
 
+// Run tests
+console.log("\n🧪 Running tests...");
+const testResult = await $`bun test`.nothrow();
+if (testResult.exitCode === 0) {
+  console.log("✓ All tests passed");
+} else {
+  console.error("✗ Tests failed");
+  errors++;
+}
+
 // Build the plugin
 console.log("\n📦 Building plugin...");
 const buildResult = await $`bun run build.ts`.nothrow();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "build.ts", "version-bump.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts", "build.ts", "version-bump.ts"]
 }


### PR DESCRIPTION
## Summary

- Remove `exclude: ["src/**/*.test.ts"]` from tsconfig.json so `tsc --noEmit` catches type errors in tests
- Add `bun test` step to validate-plugin.ts so local `bun run validate` matches CI checks

Closes #72
Closes #75

## Test plan

- [x] `bun run validate` — now runs types, tests, lint, and build (57 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)