### PR TITLE
fix: implement actual file watching in build.ts

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,19 +1,40 @@
-const watch = process.argv.includes("--watch");
+import { watch } from "node:fs";
 
-const result = await Bun.build({
-  entrypoints: ["src/main.ts"],
-  outdir: ".",
-  format: "cjs",
-  external: ["obsidian", "electron"],
-  minify: !watch,
-});
+const isWatch = process.argv.includes("--watch");
 
-if (!result.success) {
-  console.error("Build failed");
-  for (const message of result.logs) console.error(message);
-  process.exit(1);
+async function build() {
+  const result = await Bun.build({
+    entrypoints: ["src/main.ts"],
+    outdir: ".",
+    format: "cjs",
+    external: ["obsidian", "electron"],
+    minify: !isWatch,
+  });
+
+  if (!result.success) {
+    console.error("Build failed");
+    for (const message of result.logs) console.error(message);
+    if (!isWatch) process.exit(1);
+    return;
+  }
+
+  console.log(
+    `Built main.js (${(result.outputs[0].size / 1024).toFixed(1)} KB)`,
+  );
 }
 
-if (watch) console.log("Watching for changes...");
+await build();
 
-export {};
+if (isWatch) {
+  console.log("Watching src/ for changes...");
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  watch("src", { recursive: true }, (_event, filename) => {
+    if (!filename?.endsWith(".ts")) return;
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(async () => {
+      console.log(`\nRebuilding (${filename} changed)...`);
+      await build();
+    }, 100);
+  });
+}


### PR DESCRIPTION
## Summary

- Replace fake watch mode with real `fs.watch` on `src/` directory
- Rebuilds on `.ts` changes with 100ms debounce
- Build errors in watch mode log instead of exiting the process
- Removed useless empty export

Closes #66

## Test plan

- [x] `bun run validate` — all clean
- [x] `bun run build.ts` — one-shot build works
- [ ] `bun run dev` — manual: verify rebuilds on file save

🤖 Generated with [Claude Code](https://claude.com/claude-code)