### PR TITLE
test: add unit tests for publisher.ts and github-service.ts

### DIFF
--- a/src/github-service.test.ts
+++ b/src/github-service.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, mock, test } from "bun:test";
+import { GitHubService } from "./github-service";
+import type { PublisherSettings } from "./types";
+import { DEFAULT_SETTINGS } from "./types";
+
+function makeSettings(
+  overrides: Partial<PublisherSettings> = {},
+): PublisherSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    githubToken: "ghp_test",
+    repoOwner: "testowner",
+    repoName: "testrepo",
+    ...overrides,
+  };
+}
+
+function makeOctokit(overrides: Record<string, unknown> = {}) {
+  return {
+    repos: {
+      get: mock(async () => ({ data: {} })),
+      getContent: mock(async () => ({ data: { sha: "abc123" } })),
+      createOrUpdateFileContents: mock(async () => ({
+        data: { content: { html_url: "https://github.com/test/file" } },
+      })),
+    },
+    rest: {
+      git: {
+        getRef: mock(async () => ({
+          data: { object: { sha: "base-sha" } },
+        })),
+        createRef: mock(async () => ({})),
+        deleteRef: mock(async () => ({})),
+        getCommit: mock(async () => ({
+          data: { tree: { sha: "tree-sha" } },
+        })),
+        createBlob: mock(async () => ({ data: { sha: "blob-sha" } })),
+        createTree: mock(async () => ({ data: { sha: "new-tree-sha" } })),
+        createCommit: mock(async () => ({
+          data: { sha: "new-commit-sha" },
+        })),
+        updateRef: mock(async () => ({})),
+      },
+      pulls: {
+        create: mock(async () => ({
+          data: { html_url: "https://github.com/test/pr/1", number: 1 },
+        })),
+      },
+      issues: {
+        addLabels: mock(async () => ({})),
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeService(octokitOverrides: Record<string, unknown> = {}) {
+  const service = new GitHubService(makeSettings());
+  const octokit = makeOctokit(octokitOverrides);
+  (service as unknown as Record<string, unknown>).octokit = octokit;
+  return { service, octokit };
+}
+
+describe("GitHubService.getRepoUrl", () => {
+  test("returns correct URL", () => {
+    const service = new GitHubService(makeSettings());
+    expect(service.getRepoUrl()).toBe("https://github.com/testowner/testrepo");
+  });
+});
+
+describe("GitHubService.generateBranchName", () => {
+  test("generates branch name with prefix", () => {
+    const service = new GitHubService(makeSettings());
+    const name = service.generateBranchName("publish");
+    expect(name).toMatch(/^publish\/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}$/);
+  });
+
+  test("uses default prefix", () => {
+    const service = new GitHubService(makeSettings());
+    const name = service.generateBranchName();
+    expect(name).toStartWith("publish/");
+  });
+});
+
+describe("GitHubService.validateConnection", () => {
+  test("succeeds when repo is accessible", async () => {
+    const { service } = makeService();
+    await expect(service.validateConnection()).resolves.toBeUndefined();
+  });
+
+  test("throws descriptive error on failure", async () => {
+    const { service, octokit } = makeService();
+    octokit.repos.get.mockImplementation(async () => {
+      throw new Error("Not Found");
+    });
+    await expect(service.validateConnection()).rejects.toThrow(
+      "Failed to access repository",
+    );
+  });
+});
+
+describe("GitHubService.getFileSha", () => {
+  test("returns sha for existing file", async () => {
+    const { service } = makeService();
+    const sha = await service.getFileSha("content/test.md");
+    expect(sha).toBe("abc123");
+  });
+
+  test("returns null for 404", async () => {
+    const { service, octokit } = makeService();
+    const { RequestError } = await import("@octokit/request-error");
+    octokit.repos.getContent.mockImplementation(async () => {
+      throw new (RequestError as new (...args: unknown[]) => Error)(
+        "Not Found",
+        404,
+      );
+    });
+    const sha = await service.getFileSha("missing.md");
+    expect(sha).toBeNull();
+  });
+});
+
+describe("GitHubService.commitFiles", () => {
+  test("creates blobs, tree, commit, and updates ref", async () => {
+    const { service, octokit } = makeService();
+
+    await service.commitFiles(
+      [{ path: "content/test.md", content: "hello" }],
+      "test commit",
+      "main",
+    );
+
+    expect(octokit.rest.git.getRef).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.git.createBlob).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.git.createTree).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.git.createCommit).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.git.updateRef).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates one blob per file", async () => {
+    const { service, octokit } = makeService();
+
+    await service.commitFiles(
+      [
+        { path: "a.md", content: "one" },
+        { path: "b.md", content: "two" },
+        { path: "c.md", content: "three" },
+      ],
+      "batch",
+      "main",
+    );
+
+    expect(octokit.rest.git.createBlob).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("GitHubService.createPullRequest", () => {
+  test("creates PR and adds labels", async () => {
+    const { service, octokit } = makeService();
+
+    const result = await service.createPullRequest(
+      "feature",
+      "main",
+      "title",
+      "body",
+      ["chore"],
+    );
+
+    expect(result.url).toBe("https://github.com/test/pr/1");
+    expect(result.number).toBe(1);
+    expect(octokit.rest.pulls.create).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips labels when none provided", async () => {
+    const { service, octokit } = makeService();
+
+    await service.createPullRequest("feature", "main", "title", "body");
+
+    expect(octokit.rest.issues.addLabels).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHubService.createBranchWithRetry", () => {
+  test("creates branch on first attempt", async () => {
+    const { service } = makeService();
+
+    const name = await service.createBranchWithRetry("publish", "main");
+
+    expect(name).toMatch(/^publish\//);
+  });
+
+  test("throws when branch creation fails", async () => {
+    const { service, octokit } = makeService();
+    octokit.rest.git.createRef.mockImplementation(async () => {
+      throw new Error("Server error");
+    });
+
+    await expect(
+      service.createBranchWithRetry("publish", "main", 2),
+    ).rejects.toThrow("Failed to create branch");
+  });
+});

--- a/src/publisher.test.ts
+++ b/src/publisher.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, mock, test } from "bun:test";
+import { Publisher } from "./publisher";
+import { DEFAULT_SETTINGS, type PublisherSettings } from "./types";
+
+const publishedNote = `---
+title: Test Post
+status: published
+---
+Hello world`;
+
+const unpublishedNote = `---
+title: Draft
+status: draft
+---
+Not ready`;
+
+const noteWithImage = `---
+title: With Image
+status: published
+---
+Check ![[photo.png]]`;
+
+function makeSettings(
+  overrides: Partial<PublisherSettings> = {},
+): PublisherSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    githubToken: "ghp_test",
+    repoOwner: "testowner",
+    repoName: "testrepo",
+    ...overrides,
+  };
+}
+
+function makeTFile(name: string, path?: string) {
+  return {
+    name,
+    basename: name.replace(/\.md$/, ""),
+    path: path ?? name,
+    extension: "md",
+    stat: { ctime: 0, mtime: 0, size: 0 },
+    vault: {},
+    parent: null,
+  };
+}
+
+function makeVault(
+  files: Array<{ name: string; content: string | ArrayBuffer }>,
+) {
+  const mdFiles = files
+    .filter((f) => f.name.endsWith(".md"))
+    .map((f) => makeTFile(f.name));
+  const allFiles = files.map((f) => ({
+    ...makeTFile(f.name),
+    _content: f.content,
+  }));
+  const contentMap = new Map(files.map((f) => [f.name, f.content]));
+
+  return {
+    read: mock(async (file: { name: string }) => {
+      const content = contentMap.get(file.name);
+      if (content === undefined)
+        throw new Error(`File not found: ${file.name}`);
+      if (typeof content !== "string") throw new Error("Not a text file");
+      return content;
+    }),
+    readBinary: mock(async (file: { name: string }) => {
+      const content = contentMap.get(file.name);
+      if (content === undefined)
+        throw new Error(`File not found: ${file.name}`);
+      if (typeof content === "string")
+        return new TextEncoder().encode(content).buffer;
+      return content;
+    }),
+    getMarkdownFiles: mock(() => mdFiles),
+    getFiles: mock(() => allFiles),
+  };
+}
+
+function makeGitHubService() {
+  return {
+    commitFiles: mock(async () => {}),
+    createBranchWithRetry: mock(async () => "publish/2026-01-01-000000"),
+    createPullRequest: mock(async () => ({
+      url: "https://github.com/test/pr/1",
+      number: 1,
+    })),
+    deleteBranch: mock(async () => {}),
+  };
+}
+
+// Helper to inject mock github service into publisher
+function makePublisher(
+  vault: ReturnType<typeof makeVault>,
+  settings: PublisherSettings,
+  githubService?: ReturnType<typeof makeGitHubService>,
+) {
+  const publisher = new Publisher(vault as never, settings);
+  if (githubService) {
+    // Replace the real GitHubService with our mock
+    (publisher as unknown as Record<string, unknown>).githubService =
+      githubService;
+  }
+  return { publisher, githubService: githubService ?? makeGitHubService() };
+}
+
+describe("Publisher.validateSettings", () => {
+  test("returns null when all settings are valid", () => {
+    const { publisher } = makePublisher(makeVault([]), makeSettings());
+    expect(publisher.validateSettings()).toBeNull();
+  });
+
+  test("rejects missing token", () => {
+    const { publisher } = makePublisher(
+      makeVault([]),
+      makeSettings({ githubToken: "" }),
+    );
+    expect(publisher.validateSettings()).toContain("token");
+  });
+
+  test("rejects missing repo owner", () => {
+    const { publisher } = makePublisher(
+      makeVault([]),
+      makeSettings({ repoOwner: "" }),
+    );
+    expect(publisher.validateSettings()).toContain("owner");
+  });
+
+  test("rejects missing repo name", () => {
+    const { publisher } = makePublisher(
+      makeVault([]),
+      makeSettings({ repoName: "" }),
+    );
+    expect(publisher.validateSettings()).toContain("name");
+  });
+
+  test("rejects missing content dir", () => {
+    const { publisher } = makePublisher(
+      makeVault([]),
+      makeSettings({ contentDir: "" }),
+    );
+    expect(publisher.validateSettings()).toContain("Content");
+  });
+
+  test("rejects missing image dir", () => {
+    const { publisher } = makePublisher(
+      makeVault([]),
+      makeSettings({ imageDir: "" }),
+    );
+    expect(publisher.validateSettings()).toContain("Image");
+  });
+});
+
+describe("Publisher.publishNote", () => {
+  test("publishes a note with status: published", async () => {
+    const vault = makeVault([{ name: "test.md", content: publishedNote }]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNote(makeTFile("test.md") as never);
+
+    expect(result.success).toBe(true);
+    expect(gh.commitFiles).toHaveBeenCalledTimes(1);
+    const callArgs = gh.commitFiles.mock.calls[0] as unknown[];
+    const fileEntries = callArgs[0] as Array<{ path: string }>;
+    expect(fileEntries[0].path).toBe("content/posts/test.md");
+    expect(callArgs[2]).toBe("main");
+  });
+
+  test("rejects a note without publish flag", async () => {
+    const vault = makeVault([{ name: "draft.md", content: unpublishedNote }]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNote(makeTFile("draft.md") as never);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("status: published");
+    expect(gh.commitFiles).not.toHaveBeenCalled();
+  });
+
+  test("includes images in the commit", async () => {
+    const imageData = new Uint8Array([1, 2, 3]).buffer;
+    const vault = makeVault([
+      { name: "post.md", content: noteWithImage },
+      { name: "photo.png", content: imageData as unknown as string },
+    ]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNote(makeTFile("post.md") as never);
+
+    expect(result.success).toBe(true);
+    const commitCall = gh.commitFiles.mock.calls[0] as unknown[];
+    const entries = commitCall[0] as Array<{ path: string }>;
+    expect(entries).toHaveLength(2);
+    expect(entries[1].path).toBe("static/images/photo.png");
+  });
+
+  test("handles commit failure gracefully", async () => {
+    const vault = makeVault([{ name: "test.md", content: publishedNote }]);
+    const gh = makeGitHubService();
+    gh.commitFiles.mockImplementation(async () => {
+      throw new Error("API error");
+    });
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNote(makeTFile("test.md") as never);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("API error");
+  });
+});
+
+describe("Publisher.publishAll", () => {
+  test("publishes all notes with publish flag", async () => {
+    const vault = makeVault([
+      { name: "a.md", content: publishedNote },
+      { name: "b.md", content: unpublishedNote },
+      { name: "c.md", content: publishedNote },
+    ]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishAll();
+
+    expect(result.total).toBe(2);
+    expect(result.successful).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(gh.commitFiles).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns zero results when no publishable files", async () => {
+    const vault = makeVault([{ name: "draft.md", content: unpublishedNote }]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishAll();
+
+    expect(result.total).toBe(0);
+    expect(gh.commitFiles).not.toHaveBeenCalled();
+  });
+
+  test("marks all as failed when commitFiles throws", async () => {
+    const vault = makeVault([{ name: "a.md", content: publishedNote }]);
+    const gh = makeGitHubService();
+    gh.commitFiles.mockImplementation(async () => {
+      throw new Error("rate limit");
+    });
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishAll();
+
+    expect(result.successful).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.results[0].error).toContain("rate limit");
+  });
+});
+
+describe("Publisher.publishNoteWithPR", () => {
+  test("creates branch, commits, and opens PR", async () => {
+    const vault = makeVault([{ name: "test.md", content: publishedNote }]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNoteWithPR(
+      makeTFile("test.md") as never,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.prUrl).toBe("https://github.com/test/pr/1");
+    expect(gh.createBranchWithRetry).toHaveBeenCalledTimes(1);
+    expect(gh.commitFiles).toHaveBeenCalledTimes(1);
+    expect(gh.createPullRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects file without publish flag", async () => {
+    const vault = makeVault([{ name: "draft.md", content: unpublishedNote }]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNoteWithPR(
+      makeTFile("draft.md") as never,
+    );
+
+    expect(result.success).toBe(false);
+    expect(gh.createBranchWithRetry).not.toHaveBeenCalled();
+  });
+
+  test("cleans up branch on publish failure", async () => {
+    const vault = makeVault([{ name: "test.md", content: publishedNote }]);
+    const gh = makeGitHubService();
+    gh.commitFiles.mockImplementation(async () => {
+      throw new Error("commit failed");
+    });
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNoteWithPR(
+      makeTFile("test.md") as never,
+    );
+
+    expect(result.success).toBe(false);
+    expect(gh.deleteBranch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Publisher.publishAllWithPR", () => {
+  test("batches all publishable files into one PR", async () => {
+    const vault = makeVault([
+      { name: "a.md", content: publishedNote },
+      { name: "b.md", content: publishedNote },
+    ]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishAllWithPR();
+
+    expect(result.successful).toBe(2);
+    expect(result.prUrl).toBe("https://github.com/test/pr/1");
+    expect(gh.commitFiles).toHaveBeenCalledTimes(1);
+    expect(gh.createPullRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips PR when all files fail", async () => {
+    const vault = makeVault([{ name: "bad.md", content: publishedNote }]);
+    // Make the vault read throw during prepareBatch's content processing
+    vault.read.mockImplementation(async () => publishedNote);
+    const gh = makeGitHubService();
+    gh.commitFiles.mockImplementation(async () => {
+      throw new Error("commit failed");
+    });
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishAllWithPR();
+
+    expect(result.successful).toBe(0);
+    expect(result.prUrl).toBeUndefined();
+    expect(gh.deleteBranch).toHaveBeenCalled();
+  });
+
+  test("returns empty when no publishable files", async () => {
+    const vault = makeVault([{ name: "draft.md", content: unpublishedNote }]);
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishAllWithPR();
+
+    expect(result.total).toBe(0);
+    expect(gh.createBranchWithRetry).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-preload.ts
+++ b/src/test-preload.ts
@@ -1,15 +1,7 @@
 import { mock } from "bun:test";
 
 mock.module("obsidian", () => ({
-  /**
-   * Minimal mock of Obsidian APIs for testing.
-   * parseYaml/stringifyYaml use simple parsing as a stand-in since we only need
-   * basic object round-tripping in tests.
-   */
-
   parseYaml(text: string): unknown {
-    // Simple YAML parser for test fixtures: handles key: value lines,
-    // arrays like [a, b], and quoted strings
     const result: Record<string, unknown> = {};
     for (const line of text.split("\n")) {
       const trimmed = line.trim();
@@ -19,7 +11,6 @@ mock.module("obsidian", () => ({
       const key = trimmed.slice(0, colonIdx).trim();
       let value: unknown = trimmed.slice(colonIdx + 1).trim();
 
-      // Parse arrays like [a, b]
       if (
         typeof value === "string" &&
         value.startsWith("[") &&
@@ -30,9 +21,7 @@ mock.module("obsidian", () => ({
           .split(",")
           .map((s) => s.trim())
           .filter((s) => s.length > 0);
-      }
-      // Parse booleans and numbers
-      else if (value === "true") value = true;
+      } else if (value === "true") value = true;
       else if (value === "false") value = false;
       else if (typeof value === "string" && /^\d+$/.test(value))
         value = Number(value);
@@ -56,4 +45,43 @@ mock.module("obsidian", () => ({
   },
 
   Notice: class Notice {},
+
+  Plugin: class Plugin {},
+
+  PluginSettingTab: class PluginSettingTab {},
+
+  Setting: class Setting {
+    setName() {
+      return this;
+    }
+    setDesc() {
+      return this;
+    }
+    addText() {
+      return this;
+    }
+    addToggle() {
+      return this;
+    }
+    addTextArea() {
+      return this;
+    }
+    addButton() {
+      return this;
+    }
+  },
+}));
+
+mock.module("@octokit/rest", () => ({
+  Octokit: class MockOctokit {},
+}));
+
+mock.module("@octokit/request-error", () => ({
+  RequestError: class RequestError extends Error {
+    status: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.status = statusCode;
+    }
+  },
 }));


### PR DESCRIPTION
## Summary

- Extend `test-preload.ts` with mocks for Octokit, RequestError, Setting, Plugin
- New `publisher.test.ts` — 19 tests: settings validation, single/batch publish, PR workflow, error handling, image bundling
- New `github-service.test.ts` — 13 tests: connection validation, file SHA lookup, blob/tree/commit flow, PR creation, branch retry
- Test count: 47 → 79

Closes #48 (also covers #46 and #71)

## Test plan

- [x] `bun run validate` — 79 tests pass, types/lint/build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)