### PR TITLE
docs: document content transformations and hugo-coder optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Obsidian Publisher
 
-Publish [Obsidian](https://obsidian.md/) notes to GitHub for Hugo processing.
+Publish [Obsidian](https://obsidian.md/) notes to GitHub for [Hugo](https://gohugo.io/) processing. Tailored for [hugo-coder](https://github.com/luizdepra/hugo-coder) as used by [philoserf.com](https://philoserf.com).
+
+## Content Transformations
+
+The plugin converts Obsidian-specific syntax to Hugo-compatible markdown during publish:
+
+| Obsidian                 | Hugo                                                |
+| ------------------------ | --------------------------------------------------- |
+| `[[Page Name]]`          | `[Page Name]({{< ref "page-name" >}})`              |
+| `![[image.png]]`         | `![image.png](/images/image.png)`                   |
+| `![[image.png\|300]]`    | `![image.png](/images/image.png)` (sizing stripped) |
+| `![[Note Name]]` (embed) | `[Note Name]({{< ref "note-name" >}})`              |
+| `%%comment%%`            | Removed                                             |
+| `==highlight==`          | `<mark>highlight</mark>`                            |
+| `> [!note] Title`        | `{{< notice note "Title" >}}` (hugo-coder)          |
+| ` ```mermaid `           | `{{< mermaid >}}` (hugo-coder)                      |
+
+Callout types are mapped from Obsidian's ~20 types to hugo-coder's 7 notice types (`note`, `tip`, `info`, `question`, `warning`, `error`, `example`).
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Update tagline to mention Hugo and hugo-coder theme
- Add Content Transformations table documenting all syntax conversions
- Note callout type mapping (Obsidian ~20 → hugo-coder 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)