### PR TITLE
test: add image-failed case for readBinary throw (#127)

### DIFF
--- a/src/publisher.test.ts
+++ b/src/publisher.test.ts
@@ -234,6 +234,30 @@ describe("Publisher.publishNote", () => {
     ]);
   });
 
+  test("reports image-failed warning when readBinary throws", async () => {
+    const imageData = new Uint8Array([1, 2, 3]).buffer;
+    const vault = makeVault([
+      { name: "post.md", content: noteWithImage },
+      { name: "photo.png", content: imageData as unknown as string },
+    ]);
+    vault.readBinary.mockImplementation(async () => {
+      throw new Error("disk read error");
+    });
+    const gh = makeGitHubService();
+    const { publisher } = makePublisher(vault, makeSettings(), gh);
+
+    const result = await publisher.publishNote(makeTFile("post.md") as never);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([
+      { kind: "image-failed", name: "photo.png" },
+    ]);
+    const commitCall = gh.commitFiles.mock.calls[0] as unknown[];
+    const entries = commitCall[0] as Array<{ path: string }>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe("content/posts/post.md");
+  });
+
   test("reports image-collision warning with paths sorted", async () => {
     const imageData = new Uint8Array([1, 2, 3]).buffer;
     // Intentionally reverse-alphabetical to prove paths are sorted on output.


### PR DESCRIPTION
## Summary

Closes the last gap from #127. The `resolveImages` inner try/catch around `vault.readBinary` was untested — `image-failed` had coverage for "file not in vault" but not for "file found, read failed." This test exercises the `console.error` branch.

## What #127 asked for and current coverage

- Missing image in vault → covered in `publisher.test.ts:224` (added in the #126 PR)
- **Image read failure → this PR**
- Outer catch cleanup → covered by the branch-creation-throws and PR-creation-throws tests in `describe("Publisher.publishAllWithPR")` (added in #126)

## Test plan

- [x] `bun run check` clean
- [x] `bun test` — 85/85 pass
- [x] New test exercises the readBinary-throws path specifically: image is in the vault map, `readBinary` mocked to throw; asserts `success: true`, warning propagates, image absent from commit

Closes #127.