### PR TITLE
feat: ship hugo-shortcodes/ reference templates (#171)

### DIFF
--- a/hugo-shortcodes/README.md
+++ b/hugo-shortcodes/README.md
@@ -1,0 +1,61 @@
+# hugo-shortcodes
+
+Reference templates for the Hugo shortcodes emitted by [obsidian-publisher](../README.md). Copy these into your theme to render callouts and mermaid diagrams.
+
+## Install
+
+1. Copy `callout.html` to `layouts/shortcodes/callout.html` in your theme or site.
+2. Copy `mermaid.html` to `layouts/shortcodes/mermaid.html`.
+3. Copy `callout.css` to `assets/css/callout.css` (or wherever your theme bundles CSS) and wire it up from `baseof.html`:
+
+   ```html
+   {{ $css := resources.Get "css/callout.css" | resources.Minify }}
+   <link rel="stylesheet" href="{{ $css.RelPermalink }}" />
+   ```
+
+4. Copy `mermaid.js` to `assets/js/mermaid.js` and load from `baseof.html`:
+
+   ```html
+   <script type="module" src="{{ (resources.Get "js/mermaid.js").RelPermalink }}"></script>
+   ```
+
+## Shortcode names
+
+The plugin emits `{{< callout ... >}}` and `{{< mermaid >}}` by default. If you override `calloutShortcodeName` or `mermaidShortcodeName` in the plugin settings, rename these files to match (e.g., `callout.html` to `notice.html`).
+
+## Callout types
+
+The plugin passes each Obsidian callout type verbatim. `callout.css` ships styles for the common Obsidian types:
+
+- `note`
+- `abstract` / `summary` / `tldr`
+- `info` / `todo`
+- `tip` / `hint` / `important`
+- `success` / `check` / `done`
+- `question` / `help` / `faq`
+- `warning` / `caution` / `attention`
+- `failure` / `fail` / `missing`
+- `danger` / `error`
+- `bug`
+- `example`
+- `quote` / `cite`
+
+Unknown types fall back to the `.callout` defaults (the `--callout-note-bg` / `--callout-note-accent` custom properties).
+
+## Example
+
+Obsidian source:
+
+```markdown
+> [!tip] Pro tip
+> Use descriptive alt text on images.
+```
+
+After publish:
+
+```html
+<div class="callout callout-tip">
+  <div class="callout-title">Pro tip</div>
+  <div class="callout-body"><p>Use descriptive alt text on images.</p></div>
+</div>
+```

--- a/hugo-shortcodes/callout.css
+++ b/hugo-shortcodes/callout.css
@@ -1,0 +1,51 @@
+.callout {
+  --callout-bg: var(--callout-note-bg, #f0f4f8);
+  --callout-accent: var(--callout-note-accent, #4a90e2);
+  background: var(--callout-bg);
+  border-left: 4px solid var(--callout-accent);
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  border-radius: 4px;
+}
+
+.callout-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--callout-accent);
+}
+
+.callout-body > :first-child {
+  margin-top: 0;
+}
+
+.callout-body > :last-child {
+  margin-bottom: 0;
+}
+
+.callout-note      { --callout-bg: #e8f0fe; --callout-accent: #4a90e2; }
+.callout-abstract,
+.callout-summary,
+.callout-tldr      { --callout-bg: #e0f7fa; --callout-accent: #26a69a; }
+.callout-info,
+.callout-todo      { --callout-bg: #e3f2fd; --callout-accent: #2196f3; }
+.callout-tip,
+.callout-hint,
+.callout-important { --callout-bg: #fff8e1; --callout-accent: #ffa726; }
+.callout-success,
+.callout-check,
+.callout-done      { --callout-bg: #e8f5e9; --callout-accent: #43a047; }
+.callout-question,
+.callout-help,
+.callout-faq       { --callout-bg: #f3e5f5; --callout-accent: #8e24aa; }
+.callout-warning,
+.callout-caution,
+.callout-attention { --callout-bg: #fff3e0; --callout-accent: #fb8c00; }
+.callout-failure,
+.callout-fail,
+.callout-missing   { --callout-bg: #ffebee; --callout-accent: #e53935; }
+.callout-danger,
+.callout-error     { --callout-bg: #ffebee; --callout-accent: #c62828; }
+.callout-bug       { --callout-bg: #fce4ec; --callout-accent: #d81b60; }
+.callout-example   { --callout-bg: #f3e5f5; --callout-accent: #7b1fa2; }
+.callout-quote,
+.callout-cite      { --callout-bg: #f5f5f5; --callout-accent: #757575; }

--- a/hugo-shortcodes/callout.html
+++ b/hugo-shortcodes/callout.html
@@ -1,0 +1,14 @@
+{{/*
+  Callout shortcode. Receives the Obsidian callout type verbatim as the
+  first positional arg, and an optional title as the second. Usage:
+    {{< callout note "Heads up" >}} body {{< /callout >}}
+    {{< callout tldr >}} body {{< /callout >}}
+*/}}
+{{- $type := lower (.Get 0) -}}
+{{- $title := .Get 1 -}}
+<div class="callout callout-{{ $type }}">
+  {{- with $title }}<div class="callout-title">{{ . }}</div>{{ end -}}
+  <div class="callout-body">
+    {{ .Inner | markdownify }}
+  </div>
+</div>

--- a/hugo-shortcodes/callout.html
+++ b/hugo-shortcodes/callout.html
@@ -5,7 +5,10 @@
     {{< callout tldr >}} body {{< /callout >}}
 */}}
 {{- $type := lower (.Get 0) -}}
-{{- $title := .Get 1 -}}
+{{- $title := "" -}}
+{{- if gt (len .Params) 1 -}}
+  {{- $title = .Get 1 -}}
+{{- end -}}
 <div class="callout callout-{{ $type }}">
   {{- with $title }}<div class="callout-title">{{ . }}</div>{{ end -}}
   <div class="callout-body">

--- a/hugo-shortcodes/mermaid.html
+++ b/hugo-shortcodes/mermaid.html
@@ -1,0 +1,5 @@
+{{/*
+  Mermaid shortcode. Renders inner content as a <pre class="mermaid">
+  block. Pair with mermaid.js which initializes Mermaid on page load.
+*/}}
+<pre class="mermaid">{{ .Inner | safeHTML }}</pre>

--- a/hugo-shortcodes/mermaid.html
+++ b/hugo-shortcodes/mermaid.html
@@ -2,4 +2,4 @@
   Mermaid shortcode. Renders inner content as a <pre class="mermaid">
   block. Pair with mermaid.js which initializes Mermaid on page load.
 */}}
-<pre class="mermaid">{{ .Inner | safeHTML }}</pre>
+<pre class="mermaid">{{ .Inner | htmlEscape }}</pre>

--- a/hugo-shortcodes/mermaid.js
+++ b/hugo-shortcodes/mermaid.js
@@ -1,0 +1,3 @@
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+
+mermaid.initialize({ startOnLoad: true, theme: "default" });

--- a/hugo-shortcodes/mermaid.js
+++ b/hugo-shortcodes/mermaid.js
@@ -1,3 +1,5 @@
-import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+// Pinned to a specific version for reproducible builds.
+// To update: change the version number below and re-deploy.
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.esm.min.mjs";
 
 mermaid.initialize({ startOnLoad: true, theme: "default" });


### PR DESCRIPTION
## Summary
- New `hugo-shortcodes/` directory at repo root: `callout.html`, `callout.css`, `mermaid.html`, `mermaid.js`, and a README with install instructions
- Covers every Obsidian callout type the plugin passes through verbatim (note, tldr, danger, bug, etc.)
- CSS uses custom properties so themes can override per-type accents
- Mermaid loader uses `mermaid@10` ESM from jsdelivr

## Test plan
- [ ] Drop `callout.html` into a Hugo site's `layouts/shortcodes/`, publish a callout, verify HTML output
- [ ] Load `callout.css`, verify per-type styling applies
- [ ] Drop `mermaid.html` + `mermaid.js`, publish a mermaid fence, verify it renders
- [ ] Override `calloutShortcodeName` to `notice`, rename template to `notice.html`, verify still works

No source or test changes; `main.js` unchanged.

Part of composite spec alignment (#172). Coordinates with philoserf/site#687, #693. Closes #171.