### PR TITLE
docs: refresh README for post-1.6.0 state; discourage installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,39 @@
 
 Publish [Obsidian](https://obsidian.md/) notes to GitHub for [Hugo](https://gohugo.io/) processing. Tailored for [hugo-coder](https://github.com/luizdepra/hugo-coder) as used by [philoserf.com](https://philoserf.com).
 
+## You probably shouldn't install this
+
+This is personal tooling, not a general-purpose plugin. It is opinionated in ways that only make sense for one person's workflow:
+
+- **Single user.** The only known installation is the maintainer's. Breaking changes ship without migration paths (see `CHANGELOG.md` — 1.4.0 renamed the publish sentinel, 1.5.0 retired `removePublishFlag` and the `{{< ref >}}` wikilinks, 1.6.0 retired the direct-commit publish mode entirely).
+- **One target shape.** The Hugo destination is expected to look like a hugo-coder site with `content/posts/`, `static/images/`, and the shipped `hugo-shortcodes/` (callout + mermaid) installed. Other site layouts will see broken links or missing renderers.
+- **PR workflow only, mandatory.** Every publish creates a timestamped feature branch and opens a PR against `baseBranch`. There is no direct-commit escape hatch.
+- **Required frontmatter.** Notes must carry `status: publish`, plus a non-empty `title` and `date`. Missing or empty required fields fail the publish per-note.
+- **No issue triage for feature requests.** Bugs are welcome; feature requests from other users will almost always be closed as out-of-scope.
+
+If you want something similar, the code is MIT-licensed — fork it and adapt. Don't expect upstream to accommodate your workflow.
+
 ## Content Transformations
 
 The plugin converts Obsidian-specific syntax to Hugo-compatible markdown during publish:
 
-| Obsidian                 | Hugo                                                |
-| ------------------------ | --------------------------------------------------- |
-| `[[Page Name]]`          | `[Page Name]({{< ref "page-name" >}})`              |
-| `![[image.png]]`         | `![image.png](/images/image.png)`                   |
-| `![[image.png\|300]]`    | `![image.png](/images/image.png)` (sizing stripped) |
-| `![[Note Name]]` (embed) | `[Note Name]({{< ref "note-name" >}})`              |
-| `%%comment%%`            | Removed                                             |
-| `==highlight==`          | `<mark>highlight</mark>`                            |
-| `> [!note] Title`        | `{{< notice note "Title" >}}` shortcode             |
-| ` ```mermaid `           | `{{< mermaid >}}` shortcode                         |
+| Obsidian                 | Hugo                                                 |
+| ------------------------ | ---------------------------------------------------- |
+| `[[Page Name]]`          | `[Page Name](/posts/page-name/)` (if in publish set) |
+| `[[Page Name#Heading]]`  | `[Page Name#Heading](/posts/page-name/#heading)`     |
+| `[[Page\|Display]]`      | `[Display](/posts/page-name/)`                       |
+| `![[image.png]]`         | `![image.png](/images/image.png)`                    |
+| `![[image.png\|alt]]`    | `![alt](/images/image.png)`                          |
+| `![[image.png\|300]]`    | `![image.png](/images/image.png)` (sizing stripped)  |
+| `![[Note Name]]` (embed) | `[Note Name](/posts/note-name/)` (if in publish set) |
+| `%%comment%%`            | Removed                                              |
+| `==highlight==`          | `<mark>highlight</mark>`                             |
+| `> [!note] Title`        | `{{< callout note "Title" >}} … {{< /callout >}}`    |
+| ` ```mermaid `           | `{{< mermaid >}} … {{< /mermaid >}}`                 |
 
-Callout types are mapped from Obsidian's ~20 types to seven notice types (`note`, `tip`, `info`, `question`, `warning`, `error`, `example`). The destination Hugo site must define `notice` and `mermaid` shortcodes in `layouts/shortcodes/` for these outputs to render.
+Wikilinks and note embeds only resolve to URLs for notes in the **current publish set** (the notes being published in this operation). Out-of-set references degrade to plain text — so you can't publish a link to a note that isn't also being published.
+
+Callout types pass through from Obsidian verbatim (no collapse to a fixed set). The destination Hugo site must define `callout` and `mermaid` shortcodes in `layouts/shortcodes/`. Reference implementations ship in `hugo-shortcodes/` — copy them into your theme. The shortcode names are configurable in the plugin settings (default `callout` and `mermaid`).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Obsidian Publisher
 
-Publish [Obsidian](https://obsidian.md/) notes to GitHub for [Hugo](https://gohugo.io/) processing. Tailored for [hugo-coder](https://github.com/luizdepra/hugo-coder) as used by [philoserf.com](https://philoserf.com).
+Publish [Obsidian](https://obsidian.md/) notes to GitHub for [Hugo](https://gohugo.io/) processing. Tailored for [philoserf.com](https://philoserf.com).
 
 ## You probably shouldn't install this
 
 This is personal tooling, not a general-purpose plugin. It is opinionated in ways that only make sense for one person's workflow:
 
 - **Single user.** The only known installation is the maintainer's. Breaking changes ship without migration paths (see `CHANGELOG.md` — 1.4.0 renamed the publish sentinel, 1.5.0 retired `removePublishFlag` and the `{{< ref >}}` wikilinks, 1.6.0 retired the direct-commit publish mode entirely).
-- **One target shape.** The Hugo destination is expected to look like a hugo-coder site with `content/posts/`, `static/images/`, and the shipped `hugo-shortcodes/` (callout + mermaid) installed. Other site layouts will see broken links or missing renderers.
+- **One target shape.** The Hugo destination is expected to use `content/posts/`, `static/images/`, and the shipped `hugo-shortcodes/` (callout + mermaid) installed in the site's theme. Other layouts will see broken links or missing renderers.
 - **PR workflow only, mandatory.** Every publish creates a timestamped feature branch and opens a PR against `baseBranch`. There is no direct-commit escape hatch.
 - **Required frontmatter.** Notes must carry `status: publish`, plus a non-empty `title` and `date`. Missing or empty required fields fail the publish per-note.
 - **No issue triage for feature requests.** Bugs are welcome; feature requests from other users will almost always be closed as out-of-scope.


### PR DESCRIPTION
## Summary

Post-release audit (after 1.6.0 shipped) surfaced README drift. Two changes:

### Content transformations table — updated for current output

Table still referenced syntax retired in 1.5.0:
- `{{< ref "page-name" >}}` → replaced with `/posts/page-name/` URLs gated on the current publish set.
- `{{< notice ... >}}` → renamed to `{{< callout ... >}}`.
- The 12-type → 7-type callout collapse line → retired; types now pass through Obsidian verbatim.

Also added rows for 1.5.0 additions that weren't documented: `|alt` image syntax, heading-anchor wikilinks (`[[Page#Heading]]`), display-text wikilinks (`[[Page|Display]]`), note embeds gated on the publish set.

New closing paragraph explains the publish-set gating behavior (out-of-set references degrade to plain text) and points at the shipped `hugo-shortcodes/` reference implementations.

### New "You probably shouldn't install this" section

Made the plugin's opinionated nature explicit at the top of the README:

- Single-user codebase, no migration support for breaking changes (1.4, 1.5, 1.6 each shipped at least one).
- Hugo destination shape is assumed (hugo-coder, `content/posts/`, `static/images/`, shipped shortcodes).
- PR workflow is mandatory (no direct-commit since 1.6.0).
- Required frontmatter is non-negotiable.
- Feature requests from non-maintainers are out of scope.

Protects future visitors from treating this as general-purpose tooling. Points at fork + adapt as the supported path for others.

## Out of scope

- `THEORY.md` has parallel drift (still references `usePullRequests`). Will be regenerated separately.
- Three follow-up tech-debt items filed from the same audit: #204 (`prLabels` getter asymmetry), #205 (`BatchPublishResult.warnings` optional vs required), #206 (`ProgressCallback` unused at public boundary).

## Test plan

- [x] `bunx prettier --check README.md` clean.
- [x] Every transformation row matches current `content-processor.ts` behavior (spot-checked against `processFromSplit` and the transform methods).
- N/A: docs-only, no code change.